### PR TITLE
Add non-snappy specific grub modules for bootable image of grub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,3 @@
-NONSNAP_GRUB_MODULES = \
-btrfs \
-hfsplus \
-iso9660 \
-part_apple \
-part_msdos \
-password_pbkdf2 \
-zfs \
-zfscrypt \
-zfsinfo \
-lvm \
-mdraid09 \
-mdraid1x \
-raid5rec \
-raid6rec \
-
 # filtered list of modules included in the signed EFI grub image, excluding
 # ones that we don't think are useful in snappy.
 GRUB_MODULES = \
@@ -52,6 +36,20 @@ GRUB_MODULES = \
 	squash4 \
 	test \
 	true \
+	btrfs \
+	hfsplus \
+	iso9660 \
+	part_apple \
+	part_msdos \
+	password_pbkdf2 \
+	zfs \
+	zfscrypt \
+	zfsinfo \
+	lvm \
+	mdraid09 \
+	mdraid1x \
+	raid5rec \
+	raid6rec \
 	video
 
 all:

--- a/grub-cpc.cfg
+++ b/grub-cpc.cfg
@@ -117,6 +117,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu --class os {
     gfxmode $linux_gfx_mode
     insmod gzio
     if [ x$grub_platform = xxen ]; then insmod xzio; insmod lzopio; fi
+    insmod part_msdos
     insmod ext2
     set root='hd0,gpt3'
     search --label $label --set=writable
@@ -130,10 +131,11 @@ submenu 'Advanced options for Ubuntu' {
             gfxmode $linux_gfx_mode
             insmod gzio
             if [ x$grub_platform = xxen ]; then insmod xzio; insmod lzopio; fi
+            insmod part_msdos
             insmod ext2
             set root='hd0,gpt3'
             search --label $label --set=writable
-            echo    'Loading Linux 4.4.0-93-generic ...'
+            echo    'Loading Linux ...'
                 linux   /system-data/vmlinuz root=LABEL=$label ro  console=tty1 console=ttyS0
             echo    'Loading initial ramdisk ...'
             initrd  /system-data/initrd.img
@@ -143,10 +145,11 @@ submenu 'Advanced options for Ubuntu' {
             load_video
             insmod gzio
             if [ x$grub_platform = xxen ]; then insmod xzio; insmod lzopio; fi
+            insmod part_msdos
             insmod ext2
             set root='hd0,gpt3'
             search --label $label --set=writable
-            echo    'Loading Linux 4.4.0-93-generic ...'
+            echo    'Loading Linux ...'
                 linux   /system-data/vmlinuz root=LABEL=$label ro recovery nomodeset 
             echo    'Loading initial ramdisk ...'
             initrd  /system-data/initrd.img


### PR DESCRIPTION
1.We now limit a bootable image with only snappy-specific GRUB
  modules. For classic image(cloud), we'd include non-snappy specific
  modules as well.
2.The kernel version now is hardcoded in grub.cfg, which doesn't look
  good. We always have the latest kernel pre-installed during the
  rootfs generation. Also we have gadget_tree in place in advance but
  have no idea which exact kernel version number it is. Probably we'd
  get rid of kernel version number in the printout to keep it simple.